### PR TITLE
Add link to the show playlist in main menu

### DIFF
--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -319,6 +319,8 @@ screen navigation():
 
         textbutton _("About") action ShowMenu("about")
 
+        textbutton _("Watch the show!") action OpenURL("https://www.youtube.com/playlist?list=PLxQjvGipjO7kx8qRRVeZ2CNrRWQ7AZWw7")
+
         if renpy.variant("pc") or (renpy.variant("web") and not renpy.variant("mobile")):
 
             ## Help isn't necessary or relevant to mobile devices.


### PR DESCRIPTION
There is now a link in the main menu that redirects to [the OSO playlist](https://www.youtube.com/playlist?list=PLxQjvGipjO7kx8qRRVeZ2CNrRWQ7AZWw7).

![image](https://github.com/pixequil/oso-game-1/assets/49569238/c36945b5-c0c2-4491-b1c6-fe2454cf4fd7)

```renpy
textbutton _("Watch the show!") action OpenURL("https://www.youtube.com/playlist?list=PLxQjvGipjO7kx8qRRVeZ2CNrRWQ7AZWw7")
```

Fixes #72 