### PR TITLE
Ignore Sublime Text-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ CubismSdkForNative-4-*.zip
 # Works in progress, throwaway scripts, etc.
 /scratch
 /*-dists
+
+### Sublime Text
+*.sublime-workspace
+*.sublime-project


### PR DESCRIPTION
Files like `oso-game-1.sublime-project` and `oso-game-1.sublime-workspace` shall be ignored.